### PR TITLE
fix: `multiple` boolean handling / nested fields in builders

### DIFF
--- a/src/Concerns/CanMapDynamicFields.php
+++ b/src/Concerns/CanMapDynamicFields.php
@@ -37,10 +37,6 @@ trait CanMapDynamicFields
 {
     private FieldInspector $fieldInspector;
 
-    /**
-     * Maps field type strings to their corresponding field class implementations.
-     * Used as a fallback when custom fields are not available.
-     */
     private const FIELD_TYPE_MAP = [
         'text' => Text::class,
         'textarea' => Textarea::class,
@@ -57,19 +53,11 @@ trait CanMapDynamicFields
         'tags' => Tags::class,
     ];
 
-    /**
-     * Initialize the field inspector service.
-     * Called during the component's boot process.
-     */
     public function boot(): void
     {
         $this->fieldInspector = app(FieldInspector::class);
     }
 
-    /**
-     * Handle field refresh events from Livewire.
-     * Currently a placeholder for future implementation.
-     */
     #[On('refreshFields')]
     public function refresh(): void
     {
@@ -129,32 +117,16 @@ trait CanMapDynamicFields
         });
     }
 
-    /**
-     * Check if the current record exists and has fields.
-     * 
-     * @return bool True if record exists and has fields
-     */
     private function hasValidRecordWithFields(): bool
     {
         return isset($this->record) && ! $this->record->fields->isEmpty();
     }
 
-    /**
-     * Check if the current record exists.
-     * 
-     * @return bool True if record exists
-     */
     private function hasValidRecord(): bool
     {
         return isset($this->record);
     }
 
-    /**
-     * Extract form values from the data array.
-     * 
-     * @param array $data The form data
-     * @return array The extracted values
-     */
     private function extractFormValues(array $data): array
     {
         return isset($data[$this->record?->valueColumn]) ? $data[$this->record?->valueColumn] : [];
@@ -426,11 +398,6 @@ trait CanMapDynamicFields
             ->all();
     }
 
-    /**
-     * Resolve custom field implementations.
-     * 
-     * @return Collection Collection of custom field instances
-     */
     private function resolveCustomFields(): Collection
     {
         return collect(Fields::getFields())
@@ -468,14 +435,6 @@ trait CanMapDynamicFields
         return null;
     }
 
-    /**
-     * Generate the input name for a field.
-     * 
-     * @param Model $field The field model
-     * @param mixed $record The record
-     * @param bool $isNested Whether this is a nested field
-     * @return string The input name
-     */
     private function generateInputName(Model $field, mixed $record, bool $isNested): string
     {
         return $isNested ? "{$field->ulid}" : "{$record->valueColumn}.{$field->ulid}";

--- a/src/Concerns/HasDatalist.php
+++ b/src/Concerns/HasDatalist.php
@@ -21,7 +21,7 @@ trait HasDatalist
     public static function getDatalistConfig(): array
     {
         return array_merge(static::getSelectableValuesConfig(), [
-            'datalistType' => null,
+            'datalistType' => [],
         ]);
     }
 

--- a/src/Concerns/HasOptions.php
+++ b/src/Concerns/HasOptions.php
@@ -21,7 +21,7 @@ trait HasOptions
     public static function getOptionsConfig(): array
     {
         return array_merge(static::getSelectableValuesConfig(), [
-            'optionType' => null,
+            'optionType' => [],
         ]);
     }
 

--- a/src/Concerns/HasSelectableValues.php
+++ b/src/Concerns/HasSelectableValues.php
@@ -145,9 +145,9 @@ trait HasSelectableValues
                             ])
                             ->afterStateHydrated(function (Forms\Get $get, Forms\Set $set) use ($type) {
                                 $value = $get("config.{$type}");
-                                if (is_string($value)) {
-                                    $set("config.{$type}", [$value]);
-                                }
+                                
+                                // Set correct config value when creating records
+                                $set("config.{$type}", is_array($value) ? $value : (is_bool($value) ? [] : [$value]));
                             })
                             ->label(__('Type'))
                             ->live(),

--- a/src/Concerns/HasSelectableValues.php
+++ b/src/Concerns/HasSelectableValues.php
@@ -34,88 +34,150 @@ trait HasSelectableValues
 
     protected static function addValuesToInput(mixed $input, mixed $field, string $type, string $method): mixed
     {
+        // Ensure field config is properly initialized
+        if (!static::ensureFieldConfig($field, $type)) {
+            return $input;
+        }
+
         $allOptions = [];
 
         // Handle relationship options
-        if (isset($field->config[$type]) &&
-            (is_string($field->config[$type]) && $field->config[$type] === 'relationship') ||
-            (is_array($field->config[$type]) && in_array('relationship', $field->config[$type]))) {
-
-            $relationshipOptions = [];
-
-            foreach ($field->config['relations'] ?? [] as $relation) {
-                if (! isset($relation['resource'])) {
-                    continue;
-                }
-
-                $model = static::resolveResourceModel($relation['resource']);
-
-                if (! $model) {
-                    continue;
-                }
-
-                $query = $model::query();
-
-                // Apply filters if they exist
-                if (isset($relation['relationValue_filters'])) {
-                    foreach ($relation['relationValue_filters'] as $filter) {
-                        if (isset($filter['column'], $filter['operator'], $filter['value'])) {
-                            $query->where($filter['column'], $filter['operator'], $filter['value']);
-                        }
-                    }
-                }
-
-                $results = $query->get();
-
-                if ($results->isEmpty()) {
-                    continue;
-                }
-
-                $opts = $results->pluck($relation['relationValue'] ?? 'name', $relation['relationKey'])->toArray();
-
-                if (count($opts) === 0) {
-                    continue;
-                }
-
-                // Group by resource name
-                $resourceName = Str::title($relation['resource']);
-                $relationshipOptions[$resourceName] = $opts;
-            }
-
-            if (! empty($relationshipOptions)) {
-                // If both types are selected, group relationship options by resource
-                if (isset($field->config[$type]) &&
-                    (is_array($field->config[$type]) && in_array('array', $field->config[$type]))) {
-                    $allOptions = array_merge($allOptions, $relationshipOptions);
-                } else {
-                    // For single relationship type, merge all options without grouping
-                    $allOptions = array_merge($allOptions, ...array_values($relationshipOptions));
-                }
-            }
+        if (static::shouldHandleRelationshipOptions($field, $type)) {
+            $relationshipOptions = static::buildRelationshipOptions($field);
+            $allOptions = static::mergeRelationshipOptions($allOptions, $relationshipOptions, $field, $type);
         }
 
         // Handle array options
-        if (isset($field->config[$type]) &&
-            (is_string($field->config[$type]) && $field->config[$type] === 'array') ||
-            (is_array($field->config[$type]) && in_array('array', $field->config[$type]))) {
-
-            if (isset($field->config['options']) && is_array($field->config['options'])) {
-                // If both types are selected, group array options
-                if (isset($field->config[$type]) &&
-                    (is_array($field->config[$type]) && in_array('relationship', $field->config[$type]))) {
-                    $allOptions[__('Custom Options')] = $field->config['options'];
-                } else {
-                    $allOptions = array_merge($allOptions, $field->config['options']);
-                }
-            }
+        if (static::shouldHandleArrayOptions($field, $type)) {
+            $allOptions = static::mergeArrayOptions($allOptions, $field, $type);
         }
 
         // Apply all merged options to the input
-        if (! empty($allOptions)) {
+        if (!empty($allOptions)) {
             $input->$method($allOptions);
         }
 
         return $input;
+    }
+
+    protected static function ensureFieldConfig(mixed $field, string $type): bool
+    {
+        // Ensure field config exists and is an array
+        if (!isset($field->config) || !is_array($field->config)) {
+            return false;
+        }
+
+        // Ensure the type key exists in the config to prevent undefined array key errors
+        if (!array_key_exists($type, $field->config)) {
+            $config = $field->config ?? [];
+            $config[$type] = null;
+            $field->config = $config;
+        }
+
+        return true;
+    }
+
+    protected static function shouldHandleRelationshipOptions(mixed $field, string $type): bool
+    {
+        // Ensure $type is a string to prevent array key errors
+        if (!is_string($type)) {
+            return false;
+        }
+        
+        return isset($field->config[$type]) && $field->config[$type] !== null &&
+            (is_string($field->config[$type]) && $field->config[$type] === 'relationship') ||
+            (is_array($field->config[$type]) && in_array('relationship', $field->config[$type]));
+    }
+
+    protected static function shouldHandleArrayOptions(mixed $field, string $type): bool
+    {
+        // Ensure $type is a string to prevent array key errors
+        if (!is_string($type)) {
+            return false;
+        }
+        
+        return isset($field->config[$type]) && $field->config[$type] !== null &&
+            (is_string($field->config[$type]) && $field->config[$type] === 'array') ||
+            (is_array($field->config[$type]) && in_array('array', $field->config[$type]));
+    }
+
+    protected static function buildRelationshipOptions(mixed $field): array
+    {
+        $relationshipOptions = [];
+
+        foreach ($field->config['relations'] ?? [] as $relation) {
+            if (!isset($relation['resource'])) {
+                continue;
+            }
+
+            $model = static::resolveResourceModel($relation['resource']);
+
+            if (!$model) {
+                continue;
+            }
+
+            $query = $model::query();
+
+            // Apply filters if they exist
+            if (isset($relation['relationValue_filters'])) {
+                foreach ($relation['relationValue_filters'] as $filter) {
+                    if (isset($filter['column'], $filter['operator'], $filter['value'])) {
+                        $query->where($filter['column'], $filter['operator'], $filter['value']);
+                    }
+                }
+            }
+
+            $results = $query->get();
+
+            if ($results->isEmpty()) {
+                continue;
+            }
+
+            $opts = $results->pluck($relation['relationValue'] ?? 'name', $relation['relationKey'])->toArray();
+
+            if (count($opts) === 0) {
+                continue;
+            }
+
+            // Group by resource name
+            $resourceName = Str::title($relation['resource']);
+            $relationshipOptions[$resourceName] = $opts;
+        }
+
+        return $relationshipOptions;
+    }
+
+    protected static function mergeRelationshipOptions(array $allOptions, array $relationshipOptions, mixed $field, string $type): array
+    {
+        if (empty($relationshipOptions)) {
+            return $allOptions;
+        }
+
+        // If both types are selected, group relationship options by resource
+        if (isset($field->config[$type]) && $field->config[$type] !== null &&
+            (is_array($field->config[$type]) && in_array('array', $field->config[$type]))) {
+            return array_merge($allOptions, $relationshipOptions);
+        } else {
+            // For single relationship type, merge all options without grouping
+            return array_merge($allOptions, ...array_values($relationshipOptions));
+        }
+    }
+
+    protected static function mergeArrayOptions(array $allOptions, mixed $field, string $type): array
+    {
+        if (!isset($field->config['options']) || !is_array($field->config['options'])) {
+            return $allOptions;
+        }
+
+        // If both types are selected, group array options
+        if (isset($field->config[$type]) && $field->config[$type] !== null &&
+            (is_array($field->config[$type]) && in_array('relationship', $field->config[$type]))) {
+            $allOptions[__('Custom Options')] = $field->config['options'];
+        } else {
+            $allOptions = array_merge($allOptions, $field->config['options']);
+        }
+
+        return $allOptions;
     }
 
     protected static function getSelectableValuesConfig(): array

--- a/src/Fields/Select.php
+++ b/src/Fields/Select.php
@@ -8,6 +8,7 @@ use Backstage\Fields\Contracts\FieldContract;
 use Backstage\Fields\Models\Field;
 use Filament\Forms;
 use Filament\Forms\Components\Select as Input;
+use Illuminate\Database\Eloquent\Model;
 
 class Select extends Base implements FieldContract
 {
@@ -74,7 +75,7 @@ class Select extends Base implements FieldContract
         return $input;
     }
 
-    public static function mutateFormDataCallback($record, $field, array $data): array
+    public static function mutateFormDataCallback(Model $record, $field, array $data): array
     {
         if (! property_exists($record, 'valueColumn') || ! isset($record->values[$field->ulid])) {
             return $data;
@@ -86,7 +87,7 @@ class Select extends Base implements FieldContract
         return $data;
     }
 
-    public static function mutateBeforeSaveCallback($record, $field, array $data): array
+    public static function mutateBeforeSaveCallback(Model $record, $field, array $data): array
     {
         if (! property_exists($record, 'valueColumn') || ! isset($data[$record->valueColumn][$field->ulid])) {
             return $data;
@@ -150,7 +151,7 @@ class Select extends Base implements FieldContract
                                         ->inline(false),
                                     Forms\Components\Toggle::make('config.multiple')
                                         ->label(__('Multiple'))
-                                        ->helperText(__('When switching from multiple to single, the first value from existing values will be used.'))
+                                        ->helperText(__('Only first value is used when switching from multiple to single.'))
                                         ->columnSpan(2)
                                         ->inline(false),
                                     Forms\Components\Toggle::make('config.allowHtml')

--- a/src/Fields/Select.php
+++ b/src/Fields/Select.php
@@ -151,6 +151,8 @@ class Select extends Base implements FieldContract
                                         ->inline(false),
                                     Forms\Components\Toggle::make('config.multiple')
                                         ->label(__('Multiple'))
+                                        ->helperText(__('When switching from multiple to single, the first value from existing values will be used.'))
+                                        ->columnSpan(2)
                                         ->inline(false),
                                     Forms\Components\Toggle::make('config.allowHtml')
                                         ->label(__('Allow HTML'))


### PR DESCRIPTION
- [x] show correct `option_type` state when creating new fields
- [x] show correct values after changing the select `multiple` bool in fields
- [x] show correct values after changing the select `multiple` bool in fields in builders
- [x] when changing a multiple select with multiple values to a single one, the following error occurs:

> array_key_exists(): Argument #1 ($key) must be a valid array offset type
