### PR TITLE
fix: disable array casting

### DIFF
--- a/src/Fields/RichEditor.php
+++ b/src/Fields/RichEditor.php
@@ -32,7 +32,6 @@ class RichEditor extends Base implements FieldContract
         /**
          * @var Input $input
          */
-
         $input = self::applyDefaultSettings(Input::make($name), $field);
 
         $input = $input->label($field->name ?? null)
@@ -43,12 +42,8 @@ class RichEditor extends Base implements FieldContract
             ->statePath($name)
             ->live()
             ->json(false)
-            ->beforeStateDehydrated(function() {
-                return ;
-            })
-            ->saveRelationshipsUsing(function(){
-                return;
-            })
+            ->beforeStateDehydrated(function () {})
+            ->saveRelationshipsUsing(function () {})
             ->formatStateUsing(function ($state) {
                 if (empty($state)) {
                     return null;
@@ -123,7 +118,7 @@ class RichEditor extends Base implements FieldContract
 
                 return null;
             });
-            
+
         $hideCaptions = $field->config['hideCaptions'] ?? self::getDefaultConfig()['hideCaptions'];
         if ($hideCaptions) {
             $input->extraAttributes(['data-hide-captions' => 'true']);

--- a/src/Fields/RichEditor.php
+++ b/src/Fields/RichEditor.php
@@ -32,6 +32,9 @@ class RichEditor extends Base implements FieldContract
 
         $input = self::applyDefaultSettings(Input::make($name), $field);
 
+        // Disable array casting
+        $input->json(false);
+
         $input = $input->label($field->name ?? null)
             ->toolbarButtons([$field->config['toolbarButtons'] ?? self::getDefaultConfig()['toolbarButtons']])
             ->disableToolbarButtons($field->config['disableToolbarButtons'] ?? self::getDefaultConfig()['disableToolbarButtons'])

--- a/src/Fields/RichEditor.php
+++ b/src/Fields/RichEditor.php
@@ -29,11 +29,11 @@ class RichEditor extends Base implements FieldContract
 
     public static function make(string $name, ?Field $field = null): Input
     {
+        /**
+         * @var Input $input
+         */
 
         $input = self::applyDefaultSettings(Input::make($name), $field);
-
-        // Disable array casting
-        $input->json(false);
 
         $input = $input->label($field->name ?? null)
             ->toolbarButtons([$field->config['toolbarButtons'] ?? self::getDefaultConfig()['toolbarButtons']])
@@ -42,6 +42,13 @@ class RichEditor extends Base implements FieldContract
             ->placeholder('')
             ->statePath($name)
             ->live()
+            ->json(false)
+            ->beforeStateDehydrated(function() {
+                return ;
+            })
+            ->saveRelationshipsUsing(function(){
+                return;
+            })
             ->formatStateUsing(function ($state) {
                 if (empty($state)) {
                     return null;
@@ -116,7 +123,7 @@ class RichEditor extends Base implements FieldContract
 
                 return null;
             });
-
+            
         $hideCaptions = $field->config['hideCaptions'] ?? self::getDefaultConfig()['hideCaptions'];
         if ($hideCaptions) {
             $input->extraAttributes(['data-hide-captions' => 'true']);


### PR DESCRIPTION
This pull request introduces minor updates to the `RichEditor` field configuration in `src/Fields/RichEditor.php`, mostly focusing on enhancing the field's behavior and extending its customization options.

RichEditor field configuration improvements:

* Added `.json(false)` to ensure the field does not handle its state as JSON, which can help with compatibility and serialization issues.
* Introduced empty callbacks for `beforeStateDehydrated` and `saveRelationshipsUsing`, providing hooks for future customization or extension without altering current behavior.

Code clarity:

* Added a docblock to clarify the type of the `$input` variable in the `make` method, improving code readability and maintainability.